### PR TITLE
Update "WebhookUpdateRequest struct" to support additional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ go-cisco-webex-teams is a Go client library for the [Cisco Webex Teams API](http
 ## Usage ##
 
 ```go
-import "https://github.com/jbogarin/go-cisco-webex-teams/sdk"
+import "github.com/jbogarin/go-cisco-webex-teams/sdk"
 
 ```
 

--- a/docs/WebhookUpdateRequest.md
+++ b/docs/WebhookUpdateRequest.md
@@ -5,6 +5,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Name** | **string** | Webhook name. | [default to null]
 **TargetUrl** | **string** | Webhook target URL. | [default to null]
+**Secret** | **string** | Webhook secret. | [default to null]
+**Status** | **string** | Webhook status. | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/sdk/webhooks_api.go
+++ b/sdk/webhooks_api.go
@@ -27,6 +27,8 @@ type WebhookCreateRequest struct {
 type WebhookUpdateRequest struct {
 	Name      string `json:"name,omitempty"`      // Webhook name.
 	TargetURL string `json:"targetUrl,omitempty"` // Webhook target URL.
+	Secret    string `json:"secret,omitempty`     // Webhook secret.
+	Status    string `json:"status,omitempty`     // Webhook status.
 }
 
 // Webhook is the Webhook definition

--- a/sdk/webhooks_api.go
+++ b/sdk/webhooks_api.go
@@ -27,8 +27,8 @@ type WebhookCreateRequest struct {
 type WebhookUpdateRequest struct {
 	Name      string `json:"name,omitempty"`      // Webhook name.
 	TargetURL string `json:"targetUrl,omitempty"` // Webhook target URL.
-	Secret    string `json:"secret,omitempty`     // Webhook secret.
-	Status    string `json:"status,omitempty`     // Webhook status.
+	Secret    string `json:"secret,omitempty"`    // Webhook secret.
+	Status    string `json:"status,omitempty"`    // Webhook status.
 }
 
 // Webhook is the Webhook definition


### PR DESCRIPTION
The WebhookUpdateRequest struct as it currently exists does not currently support all the fields that can be updated.  This small update adds in the additional fields that are supported per the documentation https://developer.webex.com/docs/api/v1/webhooks/update-a-webhook I have updated the go file as well as the docs to reflect this change. 

I also made a small fix to the README.md file to drop the "https" from the import statement since it should not be there.

Thanks for the great library! This has made working with Webex Teams much easier!
