### PR TITLE
Add html property to Message Response structure.

### DIFF
--- a/sdk/messages_api.go
+++ b/sdk/messages_api.go
@@ -32,6 +32,7 @@ type Message struct {
 	ToPersonEmail   string    `json:"toPersonEmail,omitempty"`   // Person email (for type=direct).
 	Text            string    `json:"text,omitempty"`            // Message in plain text format.
 	Markdown        string    `json:"markdown,omitempty"`        // Message in markdown format.
+	Html            string    `json:"html,omitempty"`            // Message in HTML format.
 	Files           []string  `json:"files,omitempty"`           // File URL array.
 	PersonID        string    `json:"personId,omitempty"`        // Person ID.
 	PersonEmail     string    `json:"personEmail,omitempty"`     // Person Email.


### PR DESCRIPTION
Include `html` property to `Message` struct since the Webex API supports it:
https://developer.webex.com/docs/api/v1/messages/create-a-message. This allows for flexible parsing of the message.