### PR TITLE
Changes to allow URI & Local file upload through MessageCreateRequest

### DIFF
--- a/docs/MessageCreateRequest.md
+++ b/docs/MessageCreateRequest.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **ToPersonEmail** | **string** | Person email (for type&#x3D;direct). | [optional] [default to null]
 **Text** | **string** | Message in plain text format. | [optional] [default to null]
 **Markdown** | **string** | Message in markdown format. | [optional] [default to null]
-**Files** | **[]string** | File URL array. | [optional] [default to null]
+**Files** | **[]File** | File Struct array. | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/MessagesApi.md
+++ b/docs/MessagesApi.md
@@ -15,7 +15,7 @@ Method | HTTP request | Description
 
 Post a plain text or rich text message, and optionally, a media content attachment, to a room.
 
-Post a plain text or rich text message, and optionally, a media content attachment, to a room. The files parameter is an array, which accepts multiple values to allow for future expansion, but currently only one file may be included with the message. 
+Post a plain text or rich text message, and optionally, a media content attachment, to a room. The files parameter is an array of File struct, which accepts multiple values to allow for future expansion, but currently only one file may be included with the message. 
 
 
 ### Parameters

--- a/sdk/messages_api.go
+++ b/sdk/messages_api.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-resty/resty"
+	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
 	"github.com/peterhellberg/link"
 )
@@ -112,23 +112,23 @@ func (s *MessagesService) CreateMessage(messageCreateRequest *MessageCreateReque
 	responsePart := RestyClient.R()
 
 	if messageCreateRequest.RoomID != "" {
-		responsePart.SetMultiValueFormData(url.Values{"roomId": []string{messageCreateRequest.RoomID}})
+		responsePart.SetFormDataFromValues(url.Values{"roomId": []string{messageCreateRequest.RoomID}})
 	}
 
 	if messageCreateRequest.Markdown != "" {
-		responsePart.SetMultiValueFormData(url.Values{"markdown": []string{messageCreateRequest.Markdown}})
+		responsePart.SetFormDataFromValues(url.Values{"markdown": []string{messageCreateRequest.Markdown}})
 	}
 
 	if messageCreateRequest.Text != "" {
-		responsePart.SetMultiValueFormData(url.Values{"text": []string{messageCreateRequest.Text}})
+		responsePart.SetFormDataFromValues(url.Values{"text": []string{messageCreateRequest.Text}})
 	}
 
 	if messageCreateRequest.ToPersonEmail != "" {
-		responsePart.SetMultiValueFormData(url.Values{"toPersonEmail": []string{messageCreateRequest.ToPersonEmail}})
+		responsePart.SetFormDataFromValues(url.Values{"toPersonEmail": []string{messageCreateRequest.ToPersonEmail}})
 	}
 
 	if messageCreateRequest.ToPersonID != "" {
-		responsePart.SetMultiValueFormData(url.Values{"toPersonId": []string{messageCreateRequest.ToPersonID}})
+		responsePart.SetFormDataFromValues(url.Values{"toPersonId": []string{messageCreateRequest.ToPersonID}})
 	}
 
 	if len(messageCreateRequest.Files) > 1 {
@@ -137,7 +137,7 @@ func (s *MessagesService) CreateMessage(messageCreateRequest *MessageCreateReque
 
 	for _, fileToSend := range messageCreateRequest.Files {
 		if fileToSend.RemoteFileURI != "" {
-			responsePart.SetMultiValueFormData(url.Values{"files": []string{fileToSend.RemoteFileURI}})
+			responsePart.SetFormDataFromValues(url.Values{"files": []string{fileToSend.RemoteFileURI}})
 		} else if fileToSend.Reader != nil {
 			responsePart.SetMultipartField("files", fileToSend.Name, fileToSend.ContentType, fileToSend.Reader)
 		}

--- a/sdk/messages_api.go
+++ b/sdk/messages_api.go
@@ -200,6 +200,56 @@ func (s *MessagesService) GetMessage(messageID string) (*Message, *resty.Respons
 
 }
 
+// DirectMessagesQueryParams are the query params for the ListMessages API Call
+type DirectMessagesQueryParams struct {
+	ParentID    string `url:"parentId,omitempty"`    // List messages with a parent, by ID.
+	PersonID    string `url:"personId,omitempty"`    // List messages in a 1:1 room, by person ID.
+	PersonEmail string `url:"personEmail,omitempty"` // List messages in a 1:1 room, by person email.
+	Max         int    `url:"max,omitempty"`         // Limit the maximum number of items in the response.
+	Paginate    bool   // Indicates if pagination is needed
+}
+
+// GetDirectMessages Lists all messages in a 1:1 (direct) room.
+/* Lists all messages in a 1:1 (direct) room.
+Use the personId or personEmail query parameter to specify the room.
+ @param parentId Parent Message ID.
+ @param personId Person ID.
+ @param personEmail Person Email.
+ @return a list of Messages
+*/
+func (s *MessagesService) GetDirectMessages(queryParams *DirectMessagesQueryParams) (*Messages, *resty.Response, error) {
+	path := "/messages/direct"
+
+	queryParamsString, _ := query.Values(queryParams)
+
+	response, err := RestyClient.R().
+		SetQueryString(queryParamsString.Encode()).
+		SetResult(&Messages{}).
+		Get(path)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	result := response.Result().(*Messages)
+	if queryParams.Paginate == true {
+		items := messagesPagination(response.Header().Get("Link"), 0, 0)
+		for _, message := range items.Items {
+			result.AddMessage(message)
+		}
+	} else {
+		if len(result.Items) < queryParams.Max {
+			items := messagesPagination(response.Header().Get("Link"), len(result.Items), queryParams.Max)
+			for _, message := range items.Items {
+				result.AddMessage(message)
+			}
+		}
+	}
+
+	return result, response, err
+
+}
+
 // ListMessagesQueryParams are the query params for the ListMessages API Call
 type ListMessagesQueryParams struct {
 	RoomID          string    `url:"roomId,omitempty"`          // List messages for a room, by ID.


### PR DESCRIPTION
Modified MessageCreateRequest to accept an array of File structs instead of an array of strings, this allows remote and local file upload. Also modified  CreateMessage(messageCreateRequest *MessageCreateRequest) to use MultiValue FormData (SetFormDataFromValues) for uploads.