### PR TITLE
Add SetError() to capture webex API errors in the resty calls.

### DIFF
--- a/sdk/api_client.go
+++ b/sdk/api_client.go
@@ -69,3 +69,7 @@ func NewClient() *Client {
 
 	return c
 }
+
+// Error indicates an error from the invocation of a Webex API. See
+// the following documentation for error context: https://developer.webex.com/docs/api/basics#api-errors.
+type Error struct{}

--- a/sdk/contents_api.go
+++ b/sdk/contents_api.go
@@ -21,6 +21,7 @@ func (s *ContentsService) GetContent(contentID string) (*resty.Response, error) 
 	path = strings.Replace(path, "{"+"contentId"+"}", fmt.Sprintf("%v", contentID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {

--- a/sdk/devices.go
+++ b/sdk/devices.go
@@ -67,6 +67,7 @@ func devicesPagination(linkHeader string, size, max int) *Devices {
 		if l.Rel == "next" {
 			response, err := RestyClient.R().
 				SetResult(&Devices{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -108,6 +109,7 @@ func (s *DevicesService) CreateDeviceActivationCode(deviceCodeRequest *DeviceCod
 	response, err := RestyClient.R().
 		SetBody(deviceCodeRequest).
 		SetResult(&DeviceCode{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -132,6 +134,7 @@ func (s *DevicesService) DeleteDevice(deviceID string) (*resty.Response, error) 
 	path = strings.Replace(path, "{"+"deviceId"+"}", fmt.Sprintf("%v", deviceID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -154,6 +157,7 @@ func (s *DevicesService) GetDevice(deviceID string) (*Device, *resty.Response, e
 
 	response, err := RestyClient.R().
 		SetResult(&Device{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -215,6 +219,7 @@ func (s *DevicesService) ListDevices(queryParams *ListDevicesQueryParams) (*Devi
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Devices{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {

--- a/sdk/licenses_api.go
+++ b/sdk/licenses_api.go
@@ -39,6 +39,7 @@ func licensesPagination(linkHeader string, size, max int) *Licenses {
 
 			response, err := RestyClient.R().
 				SetResult(&Licenses{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -80,6 +81,7 @@ func (s *LicensesService) GetLicense(licenseID string) (*License, *resty.Respons
 
 	response, err := RestyClient.R().
 		SetResult(&License{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -114,6 +116,7 @@ func (s *LicensesService) ListLicenses(queryParams *ListLicensesQueryParams) (*L
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Licenses{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {

--- a/sdk/memberships_api.go
+++ b/sdk/memberships_api.go
@@ -58,6 +58,7 @@ func membershipsPagination(linkHeader string, size, max int) *Memberships {
 
 			response, err := RestyClient.R().
 				SetResult(&Memberships{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -97,6 +98,7 @@ func (s *MembershipsService) CreateMembership(membershipCreateRequest *Membershi
 	response, err := RestyClient.R().
 		SetBody(membershipCreateRequest).
 		SetResult(&Membership{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -121,6 +123,7 @@ func (s *MembershipsService) DeleteMembership(membershipID string) (*resty.Respo
 	path = strings.Replace(path, "{"+"membershipId"+"}", fmt.Sprintf("%v", membershipID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -145,6 +148,7 @@ func (s *MembershipsService) GetMembership(membershipID string) (*Membership, *r
 
 	response, err := RestyClient.R().
 		SetResult(&Membership{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -188,6 +192,7 @@ func (s *MembershipsService) ListMemberships(queryParams *ListMembershipsQueryPa
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Memberships{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -229,6 +234,7 @@ func (s *MembershipsService) UpdateMembership(membershipID string, membershipUpd
 	response, err := RestyClient.R().
 		SetBody(membershipUpdateRequest).
 		SetResult(&Membership{}).
+		SetError(&Error{}).
 		Put(path)
 
 	if err != nil {

--- a/sdk/messages_api.go
+++ b/sdk/messages_api.go
@@ -59,6 +59,7 @@ func messagesPagination(linkHeader string, size, max int) *Messages {
 
 			response, err := RestyClient.R().
 				SetResult(&Messages{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -100,6 +101,7 @@ func (s *MessagesService) CreateMessage(messageCreateRequest *MessageCreateReque
 	response, err := RestyClient.R().
 		SetBody(messageCreateRequest).
 		SetResult(&Message{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -122,6 +124,7 @@ func (s *MessagesService) DeleteMessage(messageID string) (*resty.Response, erro
 	path = strings.Replace(path, "{"+"messageId"+"}", fmt.Sprintf("%v", messageID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -146,6 +149,7 @@ func (s *MessagesService) GetMessage(messageID string) (*Message, *resty.Respons
 
 	response, err := RestyClient.R().
 		SetResult(&Message{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -189,6 +193,7 @@ func (s *MessagesService) ListMessages(queryParams *ListMessagesQueryParams) (*M
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Messages{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {

--- a/sdk/organizations_api.go
+++ b/sdk/organizations_api.go
@@ -39,6 +39,7 @@ func organizationsPagination(linkHeader string, size, max int) *Organizations {
 
 			response, err := RestyClient.R().
 				SetResult(&Organizations{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -80,6 +81,7 @@ func (s *OrganizationsService) GetOrganization(orgID string) (*Organization, *re
 
 	response, err := RestyClient.R().
 		SetResult(&Organization{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -112,6 +114,7 @@ func (s *OrganizationsService) ListOrganizations(queryParams *ListOrganizationsQ
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Organizations{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {

--- a/sdk/people_api.go
+++ b/sdk/people_api.go
@@ -80,6 +80,7 @@ func peoplePagination(linkHeader string, size, max int) *People {
 		if l.Rel == "next" {
 			response, err := RestyClient.R().
 				SetResult(&People{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -121,6 +122,7 @@ func (s *PeopleService) CreatePerson(personRequest *PersonRequest) (*Person, *re
 	response, err := RestyClient.R().
 		SetBody(personRequest).
 		SetResult(&Person{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -145,6 +147,7 @@ func (s *PeopleService) DeletePerson(personID string) (*resty.Response, error) {
 	path = strings.Replace(path, "{"+"personId"+"}", fmt.Sprintf("%v", personID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -165,6 +168,7 @@ func (s *PeopleService) GetMe() (*Person, *resty.Response, error) {
 
 	response, err := RestyClient.R().
 		SetResult(&Person{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -190,6 +194,7 @@ func (s *PeopleService) GetPerson(personID string) (*Person, *resty.Response, er
 
 	response, err := RestyClient.R().
 		SetResult(&Person{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -232,6 +237,7 @@ func (s *PeopleService) ListPeople(queryParams *ListPeopleQueryParams) (*People,
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&People{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -273,6 +279,7 @@ func (s *PeopleService) Update(personID string, personRequest *PersonRequest) (*
 	response, err := RestyClient.R().
 		SetBody(personRequest).
 		SetResult(&Person{}).
+		SetError(&Error{}).
 		Put(path)
 
 	if err != nil {

--- a/sdk/places_api.go
+++ b/sdk/places_api.go
@@ -28,7 +28,7 @@ type PlaceUpdateRequest struct {
 type Place struct {
 	ID           string    `json:"id,omitempty"`           // Place ID.
 	Title        string    `json:"title,omitempty"`        // Place title.
-	PlaceType     string    `json:"type,omitempty"`         // Place type (group or direct).
+	PlaceType    string    `json:"type,omitempty"`         // Place type (group or direct).
 	IsLocked     bool      `json:"isLocked,omitempty"`     // Place is moderated.
 	TeamID       string    `json:"teamId,omitempty"`       // Place Team ID.
 	CreatorID    string    `json:"creatorId,omitempty"`    // Place creator Person ID.
@@ -55,6 +55,7 @@ func placesPagination(linkHeader string, size, max int) *Places {
 
 			response, err := RestyClient.R().
 				SetResult(&Places{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -96,6 +97,7 @@ func (s *PlacesService) CreatePlace(placeCreateRequest *PlaceCreateRequest) (*Pl
 	response, err := RestyClient.R().
 		SetBody(placeCreateRequest).
 		SetResult(&Place{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -146,6 +148,7 @@ func (s *PlacesService) GetPlace(placeID string) (*Place, *resty.Response, error
 
 	response, err := RestyClient.R().
 		SetResult(&Place{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -159,11 +162,11 @@ func (s *PlacesService) GetPlace(placeID string) (*Place, *resty.Response, error
 
 // ListPlacesQueryParams are the query params for the ListPlaces API Call
 type ListPlacesQueryParams struct {
-	TeamID   string `url:"teamId,omitempty"` // Limit the places to those associated with a team, by ID.
+	TeamID    string `url:"teamId,omitempty"` // Limit the places to those associated with a team, by ID.
 	PlaceType string `url:"type,omitempty"`   // direct returns all 1-to-1 places. group returns all group places.
-	SortBy   string `url:"sortBy,omitempty"` // Sort results by place ID (id), most recent activity (lastactivity), or most recently created (created).
-	Max      int    `url:"max,omitempty"`    // Limit the maximum number of items in the response.
-	Paginate bool   // Indicates if pagination is needed
+	SortBy    string `url:"sortBy,omitempty"` // Sort results by place ID (id), most recent activity (lastactivity), or most recently created (created).
+	Max       int    `url:"max,omitempty"`    // Limit the maximum number of items in the response.
+	Paginate  bool   // Indicates if pagination is needed
 }
 
 // ListPlaces List places.
@@ -229,6 +232,7 @@ func (s *PlacesService) UpdatePlace(placeID string, placeUpdateRequest *PlaceUpd
 	response, err := RestyClient.R().
 		SetBody(placeUpdateRequest).
 		SetResult(&Place{}).
+		SetError(&Error{}).
 		Put(path)
 
 	if err != nil {

--- a/sdk/recordings.go
+++ b/sdk/recordings.go
@@ -67,6 +67,7 @@ func recordingsPagination(linkHeader string, size, max int) *Recordings {
 		if l.Rel == "next" {
 			response, err := RestyClient.R().
 				SetResult(&Recordings{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -122,6 +123,7 @@ func (s *RecordingsService) ListRecordings(queryParams *ListRecordingsQueryParam
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Recordings{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -158,6 +160,7 @@ func (s *RecordingsService) GetRecording(recordingID string) (*RecordingDetails,
 
 	response, err := RestyClient.R().
 		SetResult(&RecordingDetails{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {

--- a/sdk/roles_api.go
+++ b/sdk/roles_api.go
@@ -37,6 +37,7 @@ func rolesPagination(linkHeader string, size, max int) *Roles {
 
 			response, err := RestyClient.R().
 				SetResult(&Roles{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -78,6 +79,7 @@ func (s *RolesService) GetRole(roleID string) (*Role, *resty.Response, error) {
 
 	response, err := RestyClient.R().
 		SetResult(&Role{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -110,6 +112,7 @@ func (s *RolesService) ListRoles(queryParams *RolesListQueryParams) (*Roles, *re
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Roles{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {

--- a/sdk/rooms_api.go
+++ b/sdk/rooms_api.go
@@ -55,6 +55,7 @@ func roomsPagination(linkHeader string, size, max int) *Rooms {
 
 			response, err := RestyClient.R().
 				SetResult(&Rooms{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -96,6 +97,7 @@ func (s *RoomsService) CreateRoom(roomCreateRequest *RoomCreateRequest) (*Room, 
 	response, err := RestyClient.R().
 		SetBody(roomCreateRequest).
 		SetResult(&Room{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -121,6 +123,7 @@ func (s *RoomsService) DeleteRoom(roomID string) (*resty.Response, error) {
 	path = strings.Replace(path, "{"+"roomId"+"}", fmt.Sprintf("%v", roomID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -146,6 +149,7 @@ func (s *RoomsService) GetRoom(roomID string) (*Room, *resty.Response, error) {
 
 	response, err := RestyClient.R().
 		SetResult(&Room{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -188,6 +192,7 @@ func (s *RoomsService) ListRooms(queryParams *ListRoomsQueryParams) (*Rooms, *re
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Rooms{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -229,6 +234,7 @@ func (s *RoomsService) UpdateRoom(roomID string, roomUpdateRequest *RoomUpdateRe
 	response, err := RestyClient.R().
 		SetBody(roomUpdateRequest).
 		SetResult(&Room{}).
+		SetError(&Error{}).
 		Put(path)
 
 	if err != nil {

--- a/sdk/team_memberships_api.go
+++ b/sdk/team_memberships_api.go
@@ -56,6 +56,7 @@ func teamMembershipsPagination(linkHeader string, size, max int) *TeamMembership
 
 			response, err := RestyClient.R().
 				SetResult(&TeamMemberships{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -95,6 +96,7 @@ func (s *TeamMembershipsService) CreateTeamMembership(teamMemberhipCreateRequest
 	response, err := RestyClient.R().
 		SetBody(teamMemberhipCreateRequest).
 		SetResult(&TeamMembership{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -119,6 +121,7 @@ func (s *TeamMembershipsService) DeleteTeamMembership(membershipID string) (*res
 	path = strings.Replace(path, "{"+"membershipId"+"}", fmt.Sprintf("%v", membershipID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -143,6 +146,7 @@ func (s *TeamMembershipsService) GetTeamMembership(membershipID string) (*TeamMe
 
 	response, err := RestyClient.R().
 		SetResult(&TeamMembership{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -179,6 +183,7 @@ func (s *TeamMembershipsService) ListTeamMemberhips(queryParams *ListTeamMemberh
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&TeamMemberships{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -219,6 +224,7 @@ func (s *TeamMembershipsService) UpdateTeamMembership(membershipID string, teamM
 	response, err := RestyClient.R().
 		SetBody(teamMembershipUpdateRequest).
 		SetResult(&TeamMembership{}).
+		SetError(&Error{}).
 		Put(path)
 
 	if err != nil {

--- a/sdk/teams_api.go
+++ b/sdk/teams_api.go
@@ -50,6 +50,7 @@ func teamsPagination(linkHeader string, size, max int) *Teams {
 
 			response, err := RestyClient.R().
 				SetResult(&Teams{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -91,6 +92,7 @@ func (s *TeamsService) CreateTeam(teamCreateRequest *TeamCreateRequest) (*Team, 
 	response, err := RestyClient.R().
 		SetBody(teamCreateRequest).
 		SetResult(&Team{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -115,6 +117,7 @@ func (s *TeamsService) DeleteTeam(teamID string) (*resty.Response, error) {
 	path = strings.Replace(path, "{"+"teamId"+"}", fmt.Sprintf("%v", teamID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -139,6 +142,7 @@ func (s *TeamsService) GetTeam(teamID string) (*Team, *resty.Response, error) {
 
 	response, err := RestyClient.R().
 		SetResult(&Team{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -171,6 +175,7 @@ func (s *TeamsService) ListTeams(queryParams *ListTeamsQueryParams) (*Teams, *re
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Teams{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -211,6 +216,7 @@ func (s *TeamsService) UpdateTeam(teamID string, teamUpdateRequest *TeamUpdateRe
 	response, err := RestyClient.R().
 		SetBody(teamUpdateRequest).
 		SetResult(&Team{}).
+		SetError(&Error{}).
 		Put(path)
 
 	if err != nil {

--- a/sdk/webhooks_api.go
+++ b/sdk/webhooks_api.go
@@ -92,6 +92,7 @@ func webhooksPagination(linkHeader string, size, max int) *Webhooks {
 
 			response, err := RestyClient.R().
 				SetResult(&Webhooks{}).
+				SetError(&Error{}).
 				Get(l.URI)
 
 			if err != nil {
@@ -131,6 +132,7 @@ func (s *WebhooksService) CreateWebhook(webhookCreateRequest *WebhookCreateReque
 	response, err := RestyClient.R().
 		SetBody(webhookCreateRequest).
 		SetResult(&Webhook{}).
+		SetError(&Error{}).
 		Post(path)
 
 	if err != nil {
@@ -155,6 +157,7 @@ func (s *WebhooksService) DeleteWebhook(webhookID string) (*resty.Response, erro
 	path = strings.Replace(path, "{"+"webhookId"+"}", fmt.Sprintf("%v", webhookID), -1)
 
 	response, err := RestyClient.R().
+		SetError(&Error{}).
 		Delete(path)
 
 	if err != nil {
@@ -179,6 +182,7 @@ func (s *WebhooksService) GetWebhook(webhookID string) (*Webhook, *resty.Respons
 
 	response, err := RestyClient.R().
 		SetResult(&Webhook{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -211,6 +215,7 @@ func (s *WebhooksService) ListWebhooks(queryParams *ListWebhooksQueryParams) (*W
 	response, err := RestyClient.R().
 		SetQueryString(queryParamsString.Encode()).
 		SetResult(&Webhooks{}).
+		SetError(&Error{}).
 		Get(path)
 
 	if err != nil {
@@ -252,6 +257,7 @@ func (s *WebhooksService) UpdateWebhook(webhookID string, webhookUpdateRequest *
 	response, err := RestyClient.R().
 		SetBody(webhookUpdateRequest).
 		SetResult(&Webhook{}).
+		SetError(&Error{}).
 		Put(path)
 
 	if err != nil {


### PR DESCRIPTION
This patch adds the following:
- Add `Error` type to handle webex API errors from the server. In the absence of setting this explicitly, any error returned from the server is unknown. Note that the  structure of error object is not well-defined: https://developer.webex.com/docs/api/basics#api-errors. I tried a few error scenarios and `resp.Error()` has something like this:
```json
{"message":"The requested resource could not be found.","errors":[{"description":"The requested resource could not be found."}],"trackingId":"ROUTER_XYZ"}
```

- Go formatting changes after invoking `go-fmt` on `sdk/places_api.go`.