### PR TITLE
feat: add possibility to choose the number of items by resquest

### DIFF
--- a/examples/rooms/main.go
+++ b/examples/rooms/main.go
@@ -34,9 +34,9 @@ func main() {
 
 	// GET rooms
 	roomsQueryParams := &webexteams.ListRoomsQueryParams{
-		Max:      2000,
-		TeamID:   "",
-		Paginate: false,
+		Max:       -1, // list all the rooms
+		TeamID:    "",
+		RequestBy: 200, // list rooms 200 by 200
 	}
 
 	rooms, _, err := Client.Rooms.ListRooms(roomsQueryParams)

--- a/sdk/meetings_api.go
+++ b/sdk/meetings_api.go
@@ -101,21 +101,13 @@ func (s *MeetingsService) meetingsPagination(linkHeader string, size, max int) *
 				return nil
 			}
 			items = response.Result().(*Meetings)
-			if size != 0 {
-				size = size + len(items.Items)
-				if size < max {
-					meetings := s.meetingsPagination(response.Header().Get("Link"), size, max)
-					for _, meeting := range meetings.Items {
-						items.AddMeeting(meeting)
-					}
-				}
-			} else {
+			size = size + len(items.Items)
+			if max < 0 || size < max {
 				meetings := s.meetingsPagination(response.Header().Get("Link"), size, max)
 				for _, meeting := range meetings.Items {
 					items.AddMeeting(meeting)
 				}
 			}
-
 		}
 	}
 
@@ -202,8 +194,8 @@ type ListMeetingsQueryParams struct {
 	MentionedPeople string    `url:"mentionedPeople,omitempty"` // List meetings where the caller is mentioned by specifying *me* or the caller personId.
 	Before          time.Time `url:"before,omitempty"`          // List meetings sent before a date and time, in ISO8601 format. Format: yyyy-MM-dd&#39;T&#39;HH:mm:ss.SSSZ
 	BeforeMeeting   string    `url:"beforeMeeting,omitempty"`   // List meetings sent before a meeting, by ID.
-	Max             int       `url:"max,omitempty"`             // Limit the maximum number of items in the response.
-	Paginate        bool      // Indicates if pagination is needed
+	Max             int       `url:"max,omitempty"`             // Limit the maximum number of items in the response. Negative value will list all items (use this carefully).
+	RequestBy       int       `url:"-"`                         // Number of items to retrieve by requests (Max if let at 0)
 }
 
 // ListMeetings Lists all meetings in a room. Each meeting will include content attachments if present.
@@ -215,13 +207,21 @@ Long result sets will be split into pages.
  @param "mentionedPeople" (string) List meetings where the caller is mentioned by specifying *me* or the caller personId.
  @param "before" (time.Time) List meetings sent before a date and time, in ISO8601 format. Format: yyyy-MM-dd&#39;T&#39;HH:mm:ss.SSSZ
  @param "beforeMeeting" (string) List meetings sent before a meeting, by ID.
- @param "max" (int) Limit the maximum number of items in the response.
- @param "paginate" (bool) Indicates if pagination is needed
+ @param "max" (int) Limit the maximum number of items in the response. Negative value will list all items (use this carefully).
+ @param "requestBy" (int) Number of items by request
  @return Meetings
 */
 func (s *MeetingsService) ListMeetings(queryParams *ListMeetingsQueryParams) (*Meetings, *resty.Response, error) {
 
 	path := "/meetings/"
+
+	max := queryParams.Max
+
+	if queryParams.RequestBy > 0 {
+		queryParams.Max = queryParams.RequestBy
+	} else if queryParams.Max < 0 {
+		queryParams.Max = 0
+	}
 
 	queryParamsString, _ := query.Values(queryParams)
 
@@ -236,17 +236,11 @@ func (s *MeetingsService) ListMeetings(queryParams *ListMeetingsQueryParams) (*M
 	}
 
 	result := response.Result().(*Meetings)
-	if queryParams.Paginate {
-		items := s.meetingsPagination(response.Header().Get("Link"), 0, 0)
+
+	if max < 0 || len(result.Items) < max {
+		items := s.meetingsPagination(response.Header().Get("Link"), len(result.Items), max)
 		for _, meeting := range items.Items {
 			result.AddMeeting(meeting)
-		}
-	} else {
-		if len(result.Items) < queryParams.Max {
-			items := s.meetingsPagination(response.Header().Get("Link"), len(result.Items), queryParams.Max)
-			for _, meeting := range items.Items {
-				result.AddMeeting(meeting)
-			}
 		}
 	}
 

--- a/sdk/messages_api.go
+++ b/sdk/messages_api.go
@@ -96,21 +96,13 @@ func (s *MessagesService) messagesPagination(linkHeader string, size, max int) *
 				return nil
 			}
 			items = response.Result().(*Messages)
-			if size != 0 {
-				size = size + len(items.Items)
-				if size < max {
-					messages := s.messagesPagination(response.Header().Get("Link"), size, max)
-					for _, message := range messages.Items {
-						items.AddMessage(message)
-					}
-				}
-			} else {
+			size = size + len(items.Items)
+			if max < 0 || size < max {
 				messages := s.messagesPagination(response.Header().Get("Link"), size, max)
 				for _, message := range messages.Items {
 					items.AddMessage(message)
 				}
 			}
-
 		}
 	}
 
@@ -268,8 +260,8 @@ type ListMessagesQueryParams struct {
 	MentionedPeople string    `url:"mentionedPeople,omitempty"` // List messages where the caller is mentioned by specifying *me* or the caller personId.
 	Before          time.Time `url:"before,omitempty"`          // List messages sent before a date and time, in ISO8601 format. Format: yyyy-MM-dd&#39;T&#39;HH:mm:ss.SSSZ
 	BeforeMessage   string    `url:"beforeMessage,omitempty"`   // List messages sent before a message, by ID.
-	Max             int       `url:"max,omitempty"`             // Limit the maximum number of items in the response.
-	Paginate        bool      // Indicates if pagination is needed
+	Max             int       `url:"max,omitempty"`             // Limit the maximum number of items in the response. Negative value will list all items (use this carefully).
+	RequestBy       int       `url:"-"`                         // Number of items to retrieve by requests (Max if let at 0)
 }
 
 // ListMessages Lists all messages in a room. Each message will include content attachments if present.
@@ -281,13 +273,21 @@ Long result sets will be split into pages.
  @param "mentionedPeople" (string) List messages where the caller is mentioned by specifying *me* or the caller personId.
  @param "before" (time.Time) List messages sent before a date and time, in ISO8601 format. Format: yyyy-MM-dd&#39;T&#39;HH:mm:ss.SSSZ
  @param "beforeMessage" (string) List messages sent before a message, by ID.
- @param "max" (int) Limit the maximum number of items in the response.
- @param "paginate" (bool) Indicates if pagination is needed
+ @param "max" (int) Limit the maximum number of items in the response. Negative value will list all items (use this carefully).
+ @param "requestBy" (int) Number of items by request
  @return Messages
 */
 func (s *MessagesService) ListMessages(queryParams *ListMessagesQueryParams) (*Messages, *resty.Response, error) {
 
-	path := "/messages/"
+	path := "/messages"
+
+	max := queryParams.Max
+
+	if queryParams.RequestBy > 0 {
+		queryParams.Max = queryParams.RequestBy
+	} else if queryParams.Max < 0 {
+		queryParams.Max = 0
+	}
 
 	queryParamsString, _ := query.Values(queryParams)
 
@@ -302,17 +302,11 @@ func (s *MessagesService) ListMessages(queryParams *ListMessagesQueryParams) (*M
 	}
 
 	result := response.Result().(*Messages)
-	if queryParams.Paginate {
-		items := s.messagesPagination(response.Header().Get("Link"), 0, 0)
+
+	if max < 0 || len(result.Items) < max {
+		items := s.messagesPagination(response.Header().Get("Link"), len(result.Items), max)
 		for _, message := range items.Items {
 			result.AddMessage(message)
-		}
-	} else {
-		if len(result.Items) < queryParams.Max {
-			items := s.messagesPagination(response.Header().Get("Link"), len(result.Items), queryParams.Max)
-			for _, message := range items.Items {
-				result.AddMessage(message)
-			}
 		}
 	}
 
@@ -325,8 +319,8 @@ type DirectMessagesQueryParams struct {
 	ParentID    string `url:"parentId,omitempty"`    // List messages with a parent, by ID.
 	PersonID    string `url:"personId,omitempty"`    // List messages in a 1:1 room, by person ID.
 	PersonEmail string `url:"personEmail,omitempty"` // List messages in a 1:1 room, by person email.
-	Max         int    `url:"max,omitempty"`         // Limit the maximum number of items in the response.
-	Paginate    bool   // Indicates if pagination is needed
+	Max         int    `url:"max,omitempty"`         // Limit the maximum number of items in the response. Negative value will list all items (use this carefully).
+	RequestBy   int    `url:"-"`                     // Number of items to retrieve by requests (Max if let at 0)
 }
 
 // GetDirectMessages Lists all messages in a 1:1 (direct) room.
@@ -340,6 +334,14 @@ Use the personId or personEmail query parameter to specify the room.
 func (s *MessagesService) GetDirectMessages(queryParams *DirectMessagesQueryParams) (*Messages, *resty.Response, error) {
 	path := "/messages/direct"
 
+	max := queryParams.Max
+
+	if queryParams.RequestBy > 0 {
+		queryParams.Max = queryParams.RequestBy
+	} else if queryParams.Max < 0 {
+		queryParams.Max = 0
+	}
+
 	queryParamsString, _ := query.Values(queryParams)
 
 	response, err := s.client.R().
@@ -352,17 +354,11 @@ func (s *MessagesService) GetDirectMessages(queryParams *DirectMessagesQueryPara
 	}
 
 	result := response.Result().(*Messages)
-	if queryParams.Paginate == true {
-		items := s.messagesPagination(response.Header().Get("Link"), 0, 0)
+
+	if max < 0 || len(result.Items) < max {
+		items := s.messagesPagination(response.Header().Get("Link"), len(result.Items), max)
 		for _, message := range items.Items {
 			result.AddMessage(message)
-		}
-	} else {
-		if len(result.Items) < queryParams.Max {
-			items := s.messagesPagination(response.Header().Get("Link"), len(result.Items), queryParams.Max)
-			for _, message := range items.Items {
-				result.AddMessage(message)
-			}
 		}
 	}
 

--- a/sdk/webhooks_api.go
+++ b/sdk/webhooks_api.go
@@ -99,15 +99,8 @@ func (s *WebhooksService) webhooksPagination(linkHeader string, size, max int) *
 				return nil
 			}
 			items = response.Result().(*Webhooks)
-			if size != 0 {
-				size = size + len(items.Items)
-				if size < max {
-					webhooks := s.webhooksPagination(response.Header().Get("Link"), size, max)
-					for _, webhook := range webhooks.Items {
-						items.AddWebhook(webhook)
-					}
-				}
-			} else {
+			size = size + len(items.Items)
+			if max < 0 || size < max {
 				webhooks := s.webhooksPagination(response.Header().Get("Link"), size, max)
 				for _, webhook := range webhooks.Items {
 					items.AddWebhook(webhook)
@@ -196,19 +189,27 @@ func (s *WebhooksService) GetWebhook(webhookID string) (*Webhook, *resty.Respons
 
 // ListWebhooksQueryParams are the query params for the ListWebhooks API Call
 type ListWebhooksQueryParams struct {
-	Max      int  `url:"max,omitempty"` // Limit the maximum number of items in the response.
-	Paginate bool // Indicates if pagination is needed
+	Max       int `url:"max,omitempty"` // Limit the maximum number of items in the response. Negative value will list all items (use this carefully).
+	RequestBy int `url:"-"`             // Number of items to retrieve by requests (Max if let at 0)
 }
 
 // ListWebhooks Lists all of your webhooks.
 /* Lists all of your webhooks.
-@param "max" (int) Limit the maximum number of items in the response.
-@param paginate (bool) indicates if pagination is needed
+@param "max" (int) Limit the maximum number of items in the response. Negative value will list all items (use this carefully).
+@param "requestBy" (int) Number of items by request
 @return Webhooks
 */
 func (s *WebhooksService) ListWebhooks(queryParams *ListWebhooksQueryParams) (*Webhooks, *resty.Response, error) {
 
 	path := "/webhooks/"
+
+	max := queryParams.Max
+
+	if queryParams.RequestBy > 0 {
+		queryParams.Max = queryParams.RequestBy
+	} else if queryParams.Max < 0 {
+		queryParams.Max = 0
+	}
 
 	queryParamsString, _ := query.Values(queryParams)
 
@@ -223,17 +224,11 @@ func (s *WebhooksService) ListWebhooks(queryParams *ListWebhooksQueryParams) (*W
 	}
 
 	result := response.Result().(*Webhooks)
-	if queryParams.Paginate {
-		items := s.webhooksPagination(response.Header().Get("Link"), 0, 0)
+
+	if max < 0 || len(result.Items) < max {
+		items := s.webhooksPagination(response.Header().Get("Link"), len(result.Items), max)
 		for _, webhook := range items.Items {
 			result.AddWebhook(webhook)
-		}
-	} else {
-		if len(result.Items) < queryParams.Max {
-			items := s.webhooksPagination(response.Header().Get("Link"), len(result.Items), queryParams.Max)
-			for _, webhook := range items.Items {
-				result.AddWebhook(webhook)
-			}
 		}
 	}
 


### PR DESCRIPTION
PR reworking the way pagination work.

This could allow sdk users to choose how many items to retrieve at each calls by adding a RequestBy parameter. We also get rid of the Paginate parameter that was confusing (Paginate set to true means retrieving all items).
You still can retrieve all items by using a negative Max parameter (this practice should be discourage anyway).

This also fix the following issue: with the sdk it is impossible to retrieve more than 1000 rooms without retrieving all rooms. (same for all the endpoints with limited max parameter).

Of course this is a breaking change.